### PR TITLE
Allow for optional checksum

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Returns `ip-packet` configured with options.
 
 Options:
 
-* `ignoreChecksum`. Ignores checksum when decoding packets.
+* `allowNullChecksum`. When decoding, ignore checksums set to `0x0000`
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,15 +46,21 @@ Encode a packet. A packet should look like this
 }
 ```
 
-#### `packet = ip.decode(buffer, [offset], [options])
+#### `packet = ip.decode(buffer, [offset])
 
 Decode a packet. Throws an exception if the packet contains a bad checksum.
-
-Checksum is not calculated if `ignoreChecksum` flag is set in options.
 
 #### `length = ip.encodingLength(packet)`
 
 Returns the byte length of the packet encoded
+
+### `configure = ip.configure(options)`
+
+Returns `ip-packet` configured with options.
+
+Options:
+
+* `ignoreChecksum`. Ignores checksum when decoding packets.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,9 +46,11 @@ Encode a packet. A packet should look like this
 }
 ```
 
-#### `packet = ip.decode(buffer, [offset])`
+#### `packet = ip.decode(buffer, [offset], [options])
 
-Decode a packet. Throws an exception if the packet contains a bad checksum
+Decode a packet. Throws an exception if the packet contains a bad checksum.
+
+Checksum is not calculated if `ignoreChecksum` flag is set in options.
 
 #### `length = ip.encodingLength(packet)`
 

--- a/index.js
+++ b/index.js
@@ -37,9 +37,12 @@ function decode (buf, offset) {
   var ihl = buf[offset] & 15
   if (ihl > 5) throw new Error('Currently only IHL <= 5 is supported')
   var length = buf.readUInt16BE(offset + 2)
-  var sum = checksum(buf, offset, offset + 20)
+  var decodedChecksum = buf.readUInt16BE(offset + 10)
 
-  if (sum) throw new Error('Bad checksum (' + sum + ')')
+  if (decodedChecksum) {
+    var sum = checksum(buf, offset, offset + 20)
+    if (sum) throw new Error('Bad checksum (' + sum + ')')
+  }
 
   exports.decode.bytes = length
   return {
@@ -53,7 +56,7 @@ function decode (buf, offset) {
     fragmentOffset: buf.readUInt16BE(offset + 6) & 8191,
     ttl: buf[offset + 8],
     protocol: buf[offset + 9],
-    checksum: buf.readUInt16BE(offset + 10),
+    checksum: decodedChecksum,
     sourceIp: decodeIp(buf, offset + 12),
     destinationIp: decodeIp(buf, offset + 16),
     data: buf.slice(offset + 20, offset + length)

--- a/index.js
+++ b/index.js
@@ -31,8 +31,10 @@ function configure (opts) {
     var ihl = buf[offset] & 15
     if (ihl > 5) throw new Error('Currently only IHL <= 5 is supported')
     var length = buf.readUInt16BE(offset + 2)
+    var decodedChecksum = buf.readUInt16BE(offset + 10)
+    var ignoreChecksum = opts.allowNullChecksum && decodedChecksum === 0
 
-    if (!opts.ignoreChecksum) {
+    if (!ignoreChecksum) {
       var sum = checksum(buf, offset, offset + 20)
 
       if (sum) throw new Error('Bad checksum (' + sum + ')')
@@ -50,7 +52,7 @@ function configure (opts) {
       fragmentOffset: buf.readUInt16BE(offset + 6) & 8191,
       ttl: buf[offset + 8],
       protocol: buf[offset + 9],
-      checksum: buf.readUInt16BE(offset + 10),
+      checksum: decodedChecksum,
       sourceIp: decodeIp(buf, offset + 12),
       destinationIp: decodeIp(buf, offset + 16),
       data: buf.slice(offset + 20, offset + length)


### PR DESCRIPTION
This PR only calculates the checksum if the packet being decoded has a checksum. Otherwise it will simply just not calculate the checksum.

In an IP packet the checksum is strictly speaking, per the RFC, not optional. However several encoders will leave it out.

In my cases I needed it to be optional as I was decoding packets with a `0x0000` checksum. One way is to provide an `optional` parameter to the `decode` function, and another way is to check if the written checksum is `0x0000`. https://stackoverflow.com/questions/16815008/ip-header-checksum-0x0000

Do you think this work well in this package?